### PR TITLE
Add CI deploy via Ghost Admin API

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,8 @@
 /CLAUDE.md export-ignore
 /pnpm-workspace.yaml export-ignore
 /.gitattributes export-ignore
+
+# Generated build output: on an upstream-merge conflict, keep our version
+# (then rebuild with `pnpm build` after merging). Requires a one-time local:
+#   git config merge.ours.driver true
+assets/built/** merge=ours

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy theme
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+
+      - run: pnpm install --no-frozen-lockfile
+
+      # Fail the deploy if the theme doesn't pass validation.
+      - run: pnpm exec gscan --fatal --verbose .
+
+      # The deploy action zips the working tree but does NOT build, so build first.
+      - run: pnpm exec gulp build
+
+      # Packages the working directory (not a prebuilt file: zip — theme-name is
+      # ignored with file:) and uploads + activates via the Ghost Admin API.
+      - name: Deploy to Ghost
+        uses: TryGhost/action-deploy-theme@57d2c493d3fc90d624bb9b906d29066c61bbbfe1 # v2
+        with:
+          api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
+          api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}
+          theme-name: solo-evanw
+          exclude: |
+            AGENTS.md
+            CLAUDE.md
+            dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a personal fork of the [TryGhost/Solo](https://github.com/TryGhost/Solo) Ghost theme, used for evanw.com. The fork is maintained as a long-running branch with additive customizations while staying mergeable with upstream.
 
+## Committing
+
+Don't wait to be asked to commit. When the work reaches a logical checkpoint, point it out and recommend committing — but always ask for confirmation before actually running the commit.
+
 ## Commands
 
 Upstream uses **pnpm** (pinned via `packageManager` in `package.json`). Activate it once with `corepack enable pnpm`.
@@ -33,7 +37,21 @@ Current customizations:
 
 ## Merging upstream
 
-The fork tracks `upstream` (TryGhost/Solo). Customizations bleed into a few upstream-tracked files (`post.hbs`, `screen.css`, `gulpfile.js`); after merging, rebuild with `pnpm build` and commit the regenerated `assets/built/`. Deploy to the AWS host by `git pull` there (built assets are committed, so no build tooling is needed on the host).
+The fork tracks `upstream` (TryGhost/Solo). Customizations bleed into a few upstream-tracked files (`post.hbs`, `screen.css`, `gulpfile.js`); after merging, rebuild with `pnpm build` and commit the regenerated `assets/built/`.
+
+`assets/built/*` is kept committed (aligned with upstream, whose download-zip distribution model requires it). To avoid hand-resolving conflicts in those minified files on every upstream merge, `.gitattributes` marks them `merge=ours` — git keeps our version on conflict and you regenerate them with `pnpm build` afterward. This needs a **one-time** local config:
+
+```bash
+git config merge.ours.driver true
+```
+
+## Deployment
+
+Deployment is automated via GitHub Actions — the AWS host is no longer part of the deploy path (do **not** `git pull` into the live theme folder; that caused recurring `ghost doctor` permission/ownership errors from the in-folder `.git/` and login-user file ownership).
+
+Workflow: merge upstream locally → `pnpm build` → commit → merge/push to `main`. `.github/workflows/deploy.yml` then runs `gscan`, builds, and uploads + activates the theme via the Ghost **Admin API** (`TryGhost/action-deploy-theme`), which extracts it as the `ghost` user so permissions are always correct. The theme is deployed under the name `solo-evanw` (the live theme), overriding the `package.json` name `solo`.
+
+Requires two GitHub repo secrets: `GHOST_ADMIN_API_URL` (base site URL) and `GHOST_ADMIN_API_KEY` (from the Ghost custom integration). Trigger a manual deploy from the Actions tab via `workflow_dispatch`.
 
 ## Architecture
 


### PR DESCRIPTION
## What

Automate theme deployment via GitHub Actions instead of `git pull` into the live theme folder on the AWS host.

## Why

Deploying by `git pull` into the live theme directory left a `.git/` folder there (whose read-only pack files always fail Ghost's `664` permission check) and wrote files owned by the SSH login user rather than `ghost:ghost` — so `ghost doctor` / `ghost update` flagged permission + ownership errors on every update. Uploading via the Admin API instead lets Ghost extract the theme as the `ghost` user, so permissions/ownership are always correct and there is no `.git/` in the theme folder.

## Changes

- **`.github/workflows/deploy.yml`** — on push to `main` (+ manual `workflow_dispatch`): `gscan` → `gulp build` → upload + activate via `TryGhost/action-deploy-theme` as theme **`solo-evanw`** (overrides the `package.json` name `solo`). Action SHAs pinned to match `test.yml`.
- **`.gitattributes`** — `assets/built/** merge=ours` so upstream-merge conflicts in generated build files auto-resolve to our version (rebuild with `pnpm build` after merging). Requires a one-time local `git config merge.ours.driver true`.
- **`CLAUDE.md`** — document the new deploy + merge workflow and a commit-checkpoint policy.

## Before merging

Repo secrets `GHOST_ADMIN_API_URL` and `GHOST_ADMIN_API_KEY` must be set (done). Merging this triggers the first automated deploy.

## After merging (one-time host cleanup)

Confirm `solo-evanw` is active in Ghost Admin, then remove any leftover `.git/` from the old git-deployed theme folder and run `chown ghost:ghost` / `chmod 664` once more. After that, never `git pull` into the theme folder again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017owQUEA3wHy3G2CC42C6RE
