### PR TITLE
Add fork-specific README (.github/README.md)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,21 @@
+# Solo — evanw.com fork
+
+A personal fork of the [TryGhost/Solo](https://github.com/TryGhost/Solo) Ghost theme, running on [evanw.com](https://evanw.com). It tracks upstream and layers a few additive customizations on top while staying mergeable.
+
+> The original theme's README is preserved unmodified at [`/README.md`](../README.md). This file only documents what's different in this fork.
+
+## What's customized
+
+- **Heading anchor links** with copy-to-clipboard (`assets/css/custom.css` + `assets/js/custom.js`)
+- **Tighter paragraph/heading spacing** (`assets/css/custom.css`)
+- **All tags shown** in post metadata instead of just the primary tag (`post.hbs`)
+
+Customizations are deliberately isolated to `assets/css/custom.css` and `assets/js/custom.js` (plus a couple of upstream-tracked templates) to keep upstream merges clean.
+
+## How it's deployed
+
+Pushing to `main` triggers a GitHub Action ([`.github/workflows/deploy.yml`](workflows/deploy.yml)) that builds the theme and uploads it to Ghost via the Admin API — Ghost installs it as the `solo-evanw` theme. Each deploy is stamped with a traceable version like `1.0.20260623+a1b2c3d` (`<upstream major.minor>.<UTC date>+<commit>`), visible in Ghost Admin.
+
+## Contributing & issues
+
+This is a personal fork — I'm not taking feature requests here. For the original theme, see [TryGhost/Solo](https://github.com/TryGhost/Solo) and the canonical [TryGhost/Themes](https://github.com/TryGhost/Themes) monorepo. Fork maintenance notes (deploy, upstream-merge workflow) live in [`CLAUDE.md`](../CLAUDE.md).

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,8 +1,8 @@
 # Solo — evanw.com fork
 
-A personal fork of the [TryGhost/Solo](https://github.com/TryGhost/Solo) Ghost theme, running on [evanw.com](https://evanw.com). It tracks upstream and layers a few additive customizations on top while staying mergeable.
+My personal fork of the [TryGhost/Solo](https://github.com/TryGhost/Solo) Ghost theme, running on [evanw.com](https://evanw.com). It tracks upstream and adds in a few additive customizations on top while staying (generally) mergeable.
 
-> The original theme's README is preserved unmodified at [`/README.md`](../README.md). This file only documents what's different in this fork.
+The original theme's README is preserved unmodified at [`/README.md`](../README.md). This file only documents what's different in this fork.
 
 ## What's customized
 
@@ -10,7 +10,7 @@ A personal fork of the [TryGhost/Solo](https://github.com/TryGhost/Solo) Ghost t
 - **Tighter paragraph/heading spacing** (`assets/css/custom.css`)
 - **All tags shown** in post metadata instead of just the primary tag (`post.hbs`)
 
-Customizations are deliberately isolated to `assets/css/custom.css` and `assets/js/custom.js` (plus a couple of upstream-tracked templates) to keep upstream merges clean.
+Customizations are primarily isolated to `assets/css/custom.css` and `assets/js/custom.js` (plus a couple of upstream-tracked templates) to keep upstream merges clean.
 
 ## How it's deployed
 
@@ -18,4 +18,4 @@ Pushing to `main` triggers a GitHub Action ([`.github/workflows/deploy.yml`](wor
 
 ## Contributing & issues
 
-This is a personal fork — I'm not taking feature requests here. For the original theme, see [TryGhost/Solo](https://github.com/TryGhost/Solo) and the canonical [TryGhost/Themes](https://github.com/TryGhost/Themes) monorepo. Fork maintenance notes (deploy, upstream-merge workflow) live in [`CLAUDE.md`](../CLAUDE.md).
+This is a personal fork but you're welcome to contribute if your changes are specific to my forked version. For the original theme, see [TryGhost/Solo](https://github.com/TryGhost/Solo) and the canonical [TryGhost/Themes](https://github.com/TryGhost/Themes) monorepo. Fork maintenance notes (deploy, upstream-merge workflow) live in [`CLAUDE.md`](../CLAUDE.md).


### PR DESCRIPTION
Adds a fork-specific landing README at `.github/README.md`.

GitHub displays `.github/README.md` in preference to the root `README.md`, so this orients visitors to the fork while leaving the **upstream root `README.md` byte-for-byte pristine** — no merge-conflict surface (fork-only file, like `CLAUDE.md`).

Covers: what is customized, how it deploys (Admin API + version stamping), and where to file issues / find the original theme.

Holding for manual adjustments before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017owQUEA3wHy3G2CC42C6RE