### PR TITLE
Show homepage bio to everyone; split subscribe CTA into its own field

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -29,10 +29,14 @@
                 {{#if @custom.primary_header}}
                     <h1 class="gh-about-primary">{{{@custom.primary_header}}}</h1>
                 {{/if}}
+                {{!-- Fork: bio shown to everyone (upstream #395 gated secondary_header behind the member check) --}}
+                {{#if @custom.secondary_header}}
+                    <p class="gh-about-secondary">{{{@custom.secondary_header}}}</p>
+                {{/if}}
                 {{#if @site.members_enabled}}
                     {{#unless @member}}
-                        {{#if @custom.secondary_header}}
-                        <p class="gh-about-secondary">{{{@custom.secondary_header}}}</p>
+                        {{#if @custom.subscribe_pitch}}
+                        <p class="gh-about-secondary gh-about-subscribe-pitch">{{{@custom.subscribe_pitch}}}</p>
                         {{/if}}
                         <div class="gh-subscribe-input" data-portal>
                             jamie@example.com

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
                 "default": "Subscribe below to receive my latest posts directly in your inbox",
                 "group": "homepage"
             },
+            "subscribe_pitch": {
+                "type": "text",
+                "default": "Subscribe below to receive my latest posts directly in your inbox",
+                "group": "homepage"
+            },
             "post_feed_layout": {
                 "type": "select",
                 "options": ["Classic", "Typographic", "Parallax"],


### PR DESCRIPTION
## Problem

After the recent upstream update, the homepage intro blurb under "Hi! I'm Evan 👋" went blank when viewing while logged in as a member.

**Root cause:** upstream commit `bdf9984` ("[Solo] Moved the secondary header inside the member check (#395)") moved `secondary_header` *inside* the `{{#if @site.members_enabled}}{{#unless @member}}` gate in `index.hbs`, so the blurb only renders for non-members. Logged-out visitors saw it fine; the site owner (a member of their own newsletter) saw a blank area.

## Fix

Split the blurb's two concerns:

- **Bio / identity** — lift `secondary_header` *out* of the member gate so it always renders (everyone, including members).
- **Subscribe CTA** — add a new `subscribe_pitch` custom text field, kept gated to non-members, rendered just above the subscribe box.

### Changes
- `index.hbs` — restructure the about-content block; bio always visible, new gated `subscribe_pitch` paragraph. Marked with a `{{!-- Fork: … --}}` comment for future upstream merges.
- `package.json` — new `subscribe_pitch` text field in the `homepage` custom-settings group (editable in Ghost's Design customizer).

No CSS/JS touched, so no `assets/built/` rebuild needed. `gscan` passes (Ghost 6.x compatible).

## Follow-up (Ghost admin, after deploy)

The `subscribe_pitch` field only appears in the Design customizer once this is deployed. Then: trim **Secondary header** to just the bio (keep the trailing Mastodon `rel="me"` link), and paste the subscribe sentence into the new **Subscribe pitch** field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)