### PR TITLE
Normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,23 @@
 /pnpm-workspace.yaml export-ignore
 /.gitattributes export-ignore
 
+# Normalize line endings to LF, in the repo and in the working tree, on every
+# platform. This overrides each machine's core.autocrlf, so builds on Windows
+# stop churning CRLF into generated files (assets/built/**, locales/**).
+* text=auto eol=lf
+
+# Binary assets: never apply line-ending conversion.
+*.woff2 binary
+*.woff  binary
+*.ttf   binary
+*.eot   binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.zip   binary
+
 # Generated build output: on an upstream-merge conflict, keep our version
 # (then rebuild with `pnpm build` after merging). Requires a one-time local:
 #   git config merge.ours.driver true


### PR DESCRIPTION
## Problem

Building the theme on Windows (`core.autocrlf=true`) repeatedly flags generated files (`assets/built/**`, `locales/**`) as modified in `git status`, even though `git diff` shows no content change. It's pure CRLF↔LF round-tripping noise — the repo already stores everything as LF.

## Diagnosis

`git ls-files --eol` confirms every tracked text file is `i/lf` (LF in the index) but `w/crlf` (CRLF in the working tree), because `autocrlf` converts on checkout and back on commit. No file is actually stored with CRLF; nothing is corrupted.

## Fix

Pin line endings declaratively in `.gitattributes` so behavior is deterministic on every machine, independent of each developer's `core.autocrlf`:

- `* text=auto eol=lf` — normalize to LF in the repo **and** the working tree.
- Explicit `binary` entries for fonts/images (`*.woff2`, `*.png`, `*.gif`, …) so they're never touched.
- Existing `assets/built/** merge=ours` and `export-ignore` rules preserved.

`git add --renormalize .` produces **zero** content changes — repo bytes are unchanged. This only stops the cosmetic churn going forward, and after this the built/locales files no longer show as modified in `git status` despite being CRLF on disk (the attribute makes git normalize them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)