### PR TITLE
Add CSS verification tooling (cascade + headless computed-style); fix CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ A custom rule can be **present in the built stylesheet yet lose the cascade** â€
 ```bash
 pnpm verify:css           # authoritative: builds, then renders the hero in headless Chromium
                           # (Playwright) and asserts bio/pitch computed font-size match
-pnpm verify:css:cascade   # fast, no browser: resolves which font-size rule wins by
-                          # specificity + source order, straight from assets/built/screen.css
+pnpm verify:css:cascade   # fast (no browser): builds, then resolves which font-size rule
+                          # wins by specificity + source order from assets/built/screen.css
 ```
 
 Scripts live in `scripts/`. Extend them when adding hero/about customizations. `pnpm verify:css` needs Playwright's Chromium (`pnpm exec playwright install chromium`, one-time).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,27 @@ pnpm zip          # Package theme to dist/solo.zip for upload
 
 **Keep customizations isolated to minimize merge conflicts with upstream:**
 
-- **CSS**: All custom styles go in `assets/css/custom.css` (imported last in `screen.css` so they win the cascade)
+- **CSS**: All custom styles go in `assets/css/custom.css`. Note: `screen.css` `@import`s it near the **top** (3rd line, before the theme's own rules), so custom rules are inlined *before* upstream rules in the built stylesheet — they do **not** automatically win the cascade. On a specificity tie, the later (upstream) rule wins. Give custom overrides higher specificity (e.g. a compound selector like `.gh-about-secondary.gh-about-subscribe-pitch`) rather than relying on source order. Verify with `pnpm verify:css` (see Verifying CSS below).
 - **JavaScript**: All custom scripts go in `assets/js/custom.js` (conditionally included by `gulpfile.js` if file exists)
 
 Current customizations:
 - Anchor links for headings with copy-to-clipboard functionality (CSS + JS)
 - Reduced paragraph/heading spacing (`custom.css`)
 - Show all tags in post metadata instead of just `primary_tag` (`post.hbs`)
+- Homepage hero: bio shown to everyone, subscribe CTA in a gated `subscribe_pitch` custom field (`index.hbs`, `custom.css`)
+
+### Verifying CSS changes
+
+A custom rule can be **present in the built stylesheet yet lose the cascade** — verify the *computed result*, not just that the rule exists. Two checks (run after editing CSS):
+
+```bash
+pnpm verify:css           # authoritative: builds, then renders the hero in headless Chromium
+                          # (Playwright) and asserts bio/pitch computed font-size match
+pnpm verify:css:cascade   # fast, no browser: resolves which font-size rule wins by
+                          # specificity + source order, straight from assets/built/screen.css
+```
+
+Scripts live in `scripts/`. Extend them when adding hero/about customizations. `pnpm verify:css` needs Playwright's Chromium (`pnpm exec playwright install chromium`, one-time).
 
 ## Merging upstream
 

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "test": "gscan .",
         "zip": "gulp zip",
         "verify:css": "gulp build && node scripts/verify-hero-styles.mjs",
-        "verify:css:cascade": "node scripts/check-cascade.mjs"
+        "verify:css:cascade": "gulp build && node scripts/check-cascade.mjs"
     },
     "packageManager": "pnpm@11.8.0",
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,12 +48,20 @@
             },
             "navigation_layout": {
                 "type": "select",
-                "options": ["Logo on the left", "Logo in the middle", "Stacked"],
+                "options": [
+                    "Logo on the left",
+                    "Logo in the middle",
+                    "Stacked"
+                ],
                 "default": "Logo on the left"
             },
             "typography": {
                 "type": "select",
-                "options": ["Modern sans-serif", "Elegant serif", "Consistent mono"],
+                "options": [
+                    "Modern sans-serif",
+                    "Elegant serif",
+                    "Consistent mono"
+                ],
                 "default": "Modern sans-serif"
             },
             "footer_text": {
@@ -61,7 +69,11 @@
             },
             "header_section_layout": {
                 "type": "select",
-                "options": ["Side by side", "Large background", "Typographic profile"],
+                "options": [
+                    "Side by side",
+                    "Large background",
+                    "Typographic profile"
+                ],
                 "default": "Large background",
                 "group": "homepage"
             },
@@ -82,16 +94,23 @@
             },
             "post_feed_layout": {
                 "type": "select",
-                "options": ["Classic", "Typographic", "Parallax"],
+                "options": [
+                    "Classic",
+                    "Typographic",
+                    "Parallax"
+                ],
                 "default": "Classic",
                 "group": "homepage"
             }
         }
     },
     "scripts": {
+        "build": "gulp build",
         "dev": "gulp",
         "test": "gscan .",
-        "zip": "gulp zip"
+        "zip": "gulp zip",
+        "verify:css": "gulp build && node scripts/verify-hero-styles.mjs",
+        "verify:css:cascade": "node scripts/check-cascade.mjs"
     },
     "packageManager": "pnpm@11.8.0",
     "devDependencies": {
@@ -108,6 +127,7 @@
         "gulp-uglify": "3.0.2",
         "gulp-zip": "5.1.0",
         "ordered-read-streams": "2.0.0",
+        "playwright": "^1.61.0",
         "postcss": "8.5.15",
         "postcss-easy-import": "4.0.0",
         "pump": "3.0.4"

--- a/scripts/check-cascade.mjs
+++ b/scripts/check-cascade.mjs
@@ -1,0 +1,69 @@
+// Lightweight, no-browser CSS cascade check for the homepage hero.
+//
+// Why this exists: a custom rule can be PRESENT in the built stylesheet yet
+// LOSE the cascade (custom.css is inlined before the theme's own rules, so a
+// single-class tie loses on source order). "Rule present" != "rule wins".
+// This resolves, from the built CSS alone, which font-size declaration each
+// hero paragraph actually gets — by specificity then source order.
+//
+// This is a focused heuristic (it understands only the hero's selectors).
+// The authoritative check is scripts/verify-hero-styles.mjs (real browser).
+//
+// Usage: node scripts/check-cascade.mjs [path-to-built-screen.css]
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const cssPath = process.argv[2] || join(root, 'assets/built/screen.css');
+const css = readFileSync(cssPath, 'utf8');
+
+// Specificity (a,b,c): ids, classes/attrs/pseudo-classes, elements.
+function specificity(sel) {
+  const ids = (sel.match(/#[\w-]+/g) || []).length;
+  const classes = (sel.match(/\.[\w-]+|\[[^\]]+\]|:[\w-]+(?![\w-]*\()/g) || []).length;
+  const els = (sel.match(/(^|[\s>+~])[a-zA-Z][\w-]*/g) || []).length;
+  return [ids, classes, els];
+}
+const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+
+// Every rule in the built CSS that sets font-size on a .gh-about-secondary.
+const rules = [];
+const re = /([^{}]+)\{([^}]*font-size:[^;}]+;?[^}]*)\}/g;
+let m;
+while ((m = re.exec(css))) {
+  const fs = (m[2].match(/font-size:\s*([^;}]+)/) || [])[1];
+  if (!fs) continue;
+  for (const sel of m[1].split(',').map((s) => s.trim())) {
+    if (!/gh-about-secondary/.test(sel)) continue;
+    rules.push({ sel, fontSize: fs.trim(), order: m.index, spec: specificity(sel) });
+  }
+}
+
+// The two real hero elements (see index.hbs):
+//   bio   = <p class="gh-about-secondary"> directly after <h1 class="gh-about-primary">
+//   pitch = <p class="gh-about-secondary gh-about-subscribe-pitch"> (NOT adjacent to the h1)
+function matches(sel, el) {
+  if (sel.includes('.has-')) return false; // font-family variants, not size
+  if (sel.includes('+')) return el.adjacentToH1; // adjacency only matches the bio
+  const needed = (sel.match(/\.[\w-]+/g) || []).map((s) => s.slice(1));
+  return needed.every((c) => el.classes.includes(c));
+}
+const bio = { name: 'bio', classes: ['gh-about-secondary'], adjacentToH1: true };
+const pitch = { name: 'pitch', classes: ['gh-about-secondary', 'gh-about-subscribe-pitch'], adjacentToH1: false };
+
+for (const el of [bio, pitch]) {
+  const matched = rules.filter((r) => matches(r.sel, el)).sort((a, b) => cmp(a.spec, b.spec) || a.order - b.order);
+  el.win = matched.at(-1);
+  console.log(`\n[${el.name}] matching font-size rules (low -> high priority):`);
+  for (const r of matched) console.log(`   spec ${r.spec.join(',')} @${r.order}  ${r.sel}  ->  ${r.fontSize}`);
+  console.log(`   WINNER -> ${el.win?.fontSize}`);
+}
+
+const ok = bio.win && pitch.win && bio.win.fontSize === pitch.win.fontSize;
+console.log(
+  ok
+    ? `\n✅ PASS: pitch resolves to the SAME font-size as the bio (${bio.win.fontSize}).`
+    : `\n❌ FAIL: bio ${bio.win?.fontSize} vs pitch ${pitch.win?.fontSize}.`
+);
+process.exit(ok ? 0 : 1);

--- a/scripts/verify-hero-styles.mjs
+++ b/scripts/verify-hero-styles.mjs
@@ -1,0 +1,54 @@
+// Authoritative check: render the homepage hero in a real (headless) browser
+// using the BUILT stylesheet, then read computed styles. Unlike grepping the
+// CSS, this resolves the full cascade, clamp()/vw units, and inheritance — the
+// actual pixels the visitor sees — without deploying.
+//
+// Invariant: the bio paragraph and the subscribe-pitch paragraph must render at
+// the same font-size (see PR #6/#7/#9 — upstream's adjacency selector only
+// sizes the first .gh-about-secondary after the <h1>).
+//
+// Usage: node scripts/verify-hero-styles.mjs   (run after `pnpm build`)
+import { chromium } from 'playwright';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const css = readFileSync(join(root, 'assets/built/screen.css'), 'utf8');
+
+// Minimal reproduction of the index.hbs hero markup so the browser resolves the
+// real cascade against the built stylesheet.
+const html = `<!doctype html><html><head><meta charset="utf-8"><style>${css}</style></head>
+<body class="has-side-about">
+  <section class="gh-about gh-outer"><div class="gh-about-inner gh-inner">
+    <div class="gh-about-content"><div class="gh-about-content-inner">
+      <h1 class="gh-about-primary">Hi! I'm Evan</h1>
+      <p class="gh-about-secondary" id="bio">Bio paragraph.</p>
+      <p class="gh-about-secondary gh-about-subscribe-pitch" id="pitch">Subscribe pitch.</p>
+    </div></div>
+  </div></section>
+</body></html>`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+await page.setContent(html, { waitUntil: 'load' });
+
+const read = (sel) =>
+  page.$eval(sel, (el) => {
+    const cs = getComputedStyle(el);
+    return { fontSize: cs.fontSize, fontWeight: cs.fontWeight, maxWidth: cs.maxWidth };
+  });
+const bio = await read('#bio');
+const pitch = await read('#pitch');
+await browser.close();
+
+console.log('bio  :', bio);
+console.log('pitch:', pitch);
+
+const ok = bio.fontSize === pitch.fontSize;
+console.log(
+  ok
+    ? `\n✅ PASS: hero bio and subscribe pitch render at the same font-size (${bio.fontSize}).`
+    : `\n❌ FAIL: bio ${bio.fontSize} vs pitch ${pitch.fontSize}.`
+);
+process.exit(ok ? 0 : 1);

--- a/scripts/verify-hero-styles.mjs
+++ b/scripts/verify-hero-styles.mjs
@@ -29,26 +29,38 @@ const html = `<!doctype html><html><head><meta charset="utf-8"><style>${css}</st
   </div></section>
 </body></html>`;
 
-const browser = await chromium.launch();
-const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
-await page.setContent(html, { waitUntil: 'load' });
+let browser;
+try {
+  browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  await page.setContent(html, { waitUntil: 'load' });
 
-const read = (sel) =>
-  page.$eval(sel, (el) => {
-    const cs = getComputedStyle(el);
-    return { fontSize: cs.fontSize, fontWeight: cs.fontWeight, maxWidth: cs.maxWidth };
-  });
-const bio = await read('#bio');
-const pitch = await read('#pitch');
-await browser.close();
+  const read = (sel) =>
+    page.$eval(sel, (el) => {
+      const cs = getComputedStyle(el);
+      return { fontSize: cs.fontSize, fontWeight: cs.fontWeight, maxWidth: cs.maxWidth };
+    });
+  const bio = await read('#bio');
+  const pitch = await read('#pitch');
 
-console.log('bio  :', bio);
-console.log('pitch:', pitch);
+  console.log('bio  :', bio);
+  console.log('pitch:', pitch);
 
-const ok = bio.fontSize === pitch.fontSize;
-console.log(
-  ok
-    ? `\n✅ PASS: hero bio and subscribe pitch render at the same font-size (${bio.fontSize}).`
-    : `\n❌ FAIL: bio ${bio.fontSize} vs pitch ${pitch.fontSize}.`
-);
-process.exit(ok ? 0 : 1);
+  const ok = bio.fontSize === pitch.fontSize;
+  console.log(
+    ok
+      ? `\n✅ PASS: hero bio and subscribe pitch render at the same font-size (${bio.fontSize}).`
+      : `\n❌ FAIL: bio ${bio.fontSize} vs pitch ${pitch.fontSize}.`
+  );
+  process.exitCode = ok ? 0 : 1;
+} catch (err) {
+  // Most likely first-run cause: the Chromium binary isn't installed yet.
+  if (/Executable doesn't exist|playwright install/i.test(err.message)) {
+    console.error("\n❌ Chromium isn't installed. Run: pnpm exec playwright install chromium");
+  } else {
+    console.error('\n❌ verify-hero-styles failed:', err.message);
+  }
+  process.exitCode = 1;
+} finally {
+  await browser?.close();
+}


### PR DESCRIPTION
Durable follow-up to the hero font-size miss: tooling so a CSS change can be verified to actually take effect **without deploying**, plus a docs correction.

> **Stacked on #9.** This branch includes #9's fix commit (the tooling needs the fixed CSS to pass). Merge **#9 first** — then this PR auto-reduces to just the tooling/docs commit.

## Why

PR #7's rule was present in the served CSS but lost the cascade. The lesson: verify the *computed result*, not that the rule exists.

## What

- **`scripts/verify-hero-styles.mjs`** (`pnpm verify:css`) — renders the hero in headless Chromium (Playwright) against the built stylesheet and asserts the bio and subscribe-pitch computed `font-size` match. Authoritative. Output:
  ```
  bio  : { fontSize: '22.908px', fontWeight: '450', maxWidth: '640px' }
  pitch: { fontSize: '22.908px', fontWeight: '450', maxWidth: '640px' }
  ✅ PASS
  ```
- **`scripts/check-cascade.mjs`** (`pnpm verify:css:cascade`) — fast (no browser) cascade resolver: builds, then picks the winning `font-size` rule per element by specificity + source order, from `assets/built/screen.css`.
- **`CLAUDE.md` fix** — corrects the false "custom.css is imported last / wins the cascade" note (it's imported 3rd, *before* theme rules, so single-class ties lose); adds a "Verifying CSS changes" section.
- **npm scripts** — adds `build` (CLAUDE.md already assumed `pnpm build` existed) and the `verify:css*` scripts.
- **playwright** devDependency. CI uses `pnpm install --no-frozen-lockfile`, so it's unaffected; Chromium is a one-time local `pnpm exec playwright install chromium`.

## Hardening (post-review)

- **`verify:css:cascade` builds first** — it reads `assets/built/screen.css`, a build artifact. Without a build step it could silently validate stale CSS (exactly the "rule present but didn't take effect" mistake this tooling exists to catch). Now `gulp build && node scripts/check-cascade.mjs`, matching `verify:css`. Still fast — no Chromium launch.
- **`verify-hero-styles.mjs` guards the browser** — the launch is wrapped in `try/finally` so Chromium is always closed (no orphaned process on a mid-run throw), and the documented first-run case prints `❌ Chromium isn't installed. Run: pnpm exec playwright install chromium` instead of a raw Playwright stack trace.

Theme runtime is unchanged (Ghost ignores npm scripts/devDeps); no redeploy impact beyond #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
